### PR TITLE
fix: Exclude observers from EMA

### DIFF
--- a/ultralytics/__init__.py
+++ b/ultralytics/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "8.3.153+1"
+__version__ = "8.3.153+2"
 
 import os
 

--- a/ultralytics/utils/torch_utils.py
+++ b/ultralytics/utils/torch_utils.py
@@ -692,9 +692,12 @@ class ModelEMA:
             msd = de_parallel(model).state_dict()  # model state_dict
             for k, v in self.ema.state_dict().items():
                 if v.dtype.is_floating_point:  # true for FP16 and FP32
-                    v *= d
-                    v += (1 - d) * msd[k].detach()
-                    # assert v.dtype == msd[k].dtype == torch.float32, f'{k}: EMA {v.dtype},  model {msd[k].dtype}'
+                    if k.endswith(('observer.min_val', 'observer.max_val')):
+                        v.data = msd[k].detach().clone()  # hard sync for observer state
+                    else:
+                        v *= d
+                        v += (1 - d) * msd[k].detach()
+                        # assert v.dtype == msd[k].dtype == torch.float32, f'{k}: EMA {v.dtype},  model {msd[k].dtype}'
 
     def update_attr(self, model, include=(), exclude=("process_group", "reducer")):
         """


### PR DESCRIPTION
EMA neither work nor makes sense for observers and their buffers are not trainable parameters. This PR exclude them from EMA.